### PR TITLE
feat: 가게 단건 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/outsourcing/domain/menu/dto/MenuResponseFromStoreDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/menu/dto/MenuResponseFromStoreDto.java
@@ -1,0 +1,18 @@
+package com.sparta.outsourcing.domain.menu.dto;
+
+import com.sparta.outsourcing.domain.menu.entity.Menu;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuResponseFromStoreDto {
+	private String menuName;
+	private int price;
+
+	public MenuResponseFromStoreDto(Menu menu) {
+		this.menuName = menu.getMenuName();
+		this.price = menu.getPrice();
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/menu/repository/MenuRepository.java
@@ -1,4 +1,12 @@
 package com.sparta.outsourcing.domain.menu.repository;
 
-public class MenuRepository {
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.outsourcing.domain.menu.entity.Menu;
+import com.sparta.outsourcing.domain.store.entity.Store;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+	Page<Menu> findAllByStoreContaining(Store store, Pageable menuPageable);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/review/dto/ReviewResponseFromStoreDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/dto/ReviewResponseFromStoreDto.java
@@ -1,0 +1,18 @@
+package com.sparta.outsourcing.domain.review.dto;
+
+import com.sparta.outsourcing.domain.review.entity.Review;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReviewResponseFromStoreDto {
+	private Long memberId;
+	private int rating;
+
+	public ReviewResponseFromStoreDto(Review review) {
+		this.memberId = review.getId();
+		this.rating = review.getRating();
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/repository/ReviewRepository.java
@@ -1,4 +1,12 @@
 package com.sparta.outsourcing.domain.review.repository;
 
-public class ReviewRepository {
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.outsourcing.domain.review.entity.Review;
+import com.sparta.outsourcing.domain.store.entity.Store;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+	Page<Review> findAllByStoreContaining(Store store, Pageable reviewPageable);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/controller/StoreController.java
@@ -1,20 +1,24 @@
 package com.sparta.outsourcing.domain.store.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sparta.outsourcing.domain.store.dto.DetailedStoreResponseDto;
+import com.sparta.outsourcing.domain.store.dto.ShortStoreResponseDto;
 import com.sparta.outsourcing.domain.member.entity.MemberRole;
 import com.sparta.outsourcing.domain.store.dto.StoreRequestDto;
 import com.sparta.outsourcing.domain.store.dto.StoreResponseDto;
 import com.sparta.outsourcing.domain.store.service.StoreService;
 
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -32,5 +36,23 @@ public class StoreController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(
 			storeService.createStore(requestDto, memberId)
 		);
+	}
+
+	@GetMapping("/stores")
+	public ResponseEntity<Page<ShortStoreResponseDto>> getStore(
+		@RequestParam(required = false) String storeName,
+		@RequestParam(defaultValue = "0") int page
+	) {
+		if (storeName != null && !storeName.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.OK).body(storeService.getAllStoreByName(storeName, page));
+		}
+		return ResponseEntity.status(HttpStatus.OK).body(storeService.getAllStore(page));
+	}
+
+	@GetMapping("/stores/{storeId}")
+	public ResponseEntity<DetailedStoreResponseDto> getOneStore(
+		@PathVariable Long storeId
+	) {
+		return ResponseEntity.status(HttpStatus.OK).body(storeService.getOneStore(storeId));
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/DetailedStoreResponseDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/DetailedStoreResponseDto.java
@@ -1,0 +1,36 @@
+package com.sparta.outsourcing.domain.store.dto;
+
+import java.sql.Time;
+
+import org.springframework.data.domain.Page;
+
+import com.sparta.outsourcing.domain.menu.dto.MenuResponseFromStoreDto;
+import com.sparta.outsourcing.domain.review.dto.ReviewResponseFromStoreDto;
+import com.sparta.outsourcing.domain.store.entity.Store;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DetailedStoreResponseDto {
+	private Long id;
+	private String storeName;
+	private Time openTime;
+	private Time closeTime;
+	private String createdAt;
+	private String modifiedAt;
+	private Page<MenuResponseFromStoreDto> menus;
+	private Page<ReviewResponseFromStoreDto> reviews;
+
+	public DetailedStoreResponseDto(Store store, Page<MenuResponseFromStoreDto> menus, Page<ReviewResponseFromStoreDto> reviews) {
+		this.id = store.getId();
+		this.storeName = store.getStoreName();
+		this.openTime = store.getOpenTime();
+		this.closeTime = store.getCloseTime();
+		this.createdAt = store.getCreatedAt().toString();
+		this.modifiedAt = store.getModifiedAt().toString();
+		this.menus = menus;
+		this.reviews = reviews;
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/ShortStoreResponseDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/ShortStoreResponseDto.java
@@ -1,0 +1,16 @@
+package com.sparta.outsourcing.domain.store.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ShortStoreResponseDto {
+	private Long id;
+	private String storeName;
+
+	public ShortStoreResponseDto(Long id, String storeName) {
+		this.id = id;
+		this.storeName = storeName;
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
@@ -1,5 +1,7 @@
 package com.sparta.outsourcing.domain.store.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.outsourcing.domain.member.entity.Member;
@@ -7,4 +9,5 @@ import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 	int countAllByUser(Member member);
+	Page<Store> findAllByStoreNameContaining(String storeName, Pageable pageable);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
@@ -1,10 +1,22 @@
 package com.sparta.outsourcing.domain.store.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.member.entity.MemberRole;
 import com.sparta.outsourcing.domain.member.repository.MemberRepository;
+import com.sparta.outsourcing.domain.menu.dto.MenuResponseFromStoreDto;
+import com.sparta.outsourcing.domain.menu.entity.Menu;
+import com.sparta.outsourcing.domain.menu.repository.MenuRepository;
+import com.sparta.outsourcing.domain.review.dto.ReviewResponseFromStoreDto;
+import com.sparta.outsourcing.domain.review.entity.Review;
+import com.sparta.outsourcing.domain.review.repository.ReviewRepository;
+import com.sparta.outsourcing.domain.store.dto.DetailedStoreResponseDto;
+import com.sparta.outsourcing.domain.store.dto.ShortStoreResponseDto;
 import com.sparta.outsourcing.domain.store.dto.StoreRequestDto;
 import com.sparta.outsourcing.domain.store.dto.StoreResponseDto;
 import com.sparta.outsourcing.domain.store.entity.Store;
@@ -18,6 +30,8 @@ public class StoreService {
 
 	private final StoreRepository storeRepository;
 	private final MemberRepository memberRepository;
+	private final MenuRepository menuRepository;
+	private final ReviewRepository reviewRepository;
 
 	public StoreResponseDto createStore(StoreRequestDto requestDto, Long memberId) {
 		Member storeOwner = memberRepository.findById(memberId).orElseThrow(
@@ -36,5 +50,35 @@ public class StoreService {
 		storeRepository.save(store);
 
 		return new StoreResponseDto(store);
+	}
+
+	public Page<ShortStoreResponseDto> getAllStoreByName(String storeName, int page) {
+		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
+		Page<Store> stores = storeRepository.findAllByStoreNameContaining(storeName, pageable);
+		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
+	}
+
+	public Page<ShortStoreResponseDto> getAllStore(int page) {
+		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
+		Page<Store> stores = storeRepository.findAll(pageable);
+		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
+	}
+
+	public DetailedStoreResponseDto getOneStore(Long storeId) {
+		Store store = storeRepository.findById(storeId).orElseThrow(
+			() -> new IllegalArgumentException("해당하는 가게가 없습니다.")
+		);
+
+		Pageable menuPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
+		Page<Menu> menus = menuRepository.findAllByStoreContaining(store, menuPageable);
+
+		Pageable reviewPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
+		Page<Review> reviews = reviewRepository.findAllByStoreContaining(store, reviewPageable);
+
+		return new DetailedStoreResponseDto(
+			store,
+			menus.map(MenuResponseFromStoreDto::new),
+			reviews.map(ReviewResponseFromStoreDto::new)
+		);
 	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
가게를 단일 조회할 경우, 해당 가게에 있는 메뉴들, 가게에 달린 리뷰들이 다 함께 조회되어야 합니다.
지금 Page 객체를 사용해서 수정일자 내림차순 기준 5개만 조회하도록 해 놨습니다.
<!---- Resolves: #22 -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).