### PR TITLE
fix: JPQL을 사용해서 Entity를 조회할 때, isDeleted=false를 확인하는 로직을 추가하고 재 탐색하도록 코드수정

### DIFF
--- a/src/main/java/com/sparta/outsourcing/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/entity/Member.java
@@ -40,7 +40,7 @@ public class Member extends TimeStamped {
 	@Enumerated(EnumType.STRING)
 	private MemberRole role;
 
-	private boolean isDeleted;
+	private boolean delete;
 
 	private Member(String username, String password, String email, String address, MemberRole role) {
 		this.username = username;
@@ -48,7 +48,7 @@ public class Member extends TimeStamped {
 		this.email = email;
 		this.address = address;
 		this.role = role;
-		this.isDeleted = false;
+		this.delete = false;
 	}
 
 	public static Member createOf(String username, String password, String email, String address, MemberRole role) {
@@ -56,6 +56,6 @@ public class Member extends TimeStamped {
 	}
 
 	public void delete() {
-		isDeleted = true;
+		delete = true;
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/service/MemberService.java
@@ -77,15 +77,15 @@ public class MemberService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        if (member.isDeleted()) {
+        if (member.isDelete()) {
             throw new IllegalArgumentException("이미 삭제된 회원입니다.");
         }
 
         member.delete();
 
-        List<Store> stores = storeRepository.findAllByActiveMember(member);
+        List<Store> stores = storeRepository.findAllByMemberAndDeleteFalse(member);
         stores.forEach(store -> {
-            List<Menu> menus = menuRepository.findAllByActiveStore(store);
+            List<Menu> menus = menuRepository.findAllByStoreAndDeleteFalse(store);
             menus.forEach(Menu::delete);
             menuRepository.saveAll(menus);
             store.delete();
@@ -93,7 +93,7 @@ public class MemberService {
         );
         storeRepository.saveAll(stores);
 
-        List<Order> orders = orderRepository.findAllByActiveMember(member);
+        List<Order> orders = orderRepository.findAllByMemberAndDeleteFalse(member);
         orders.forEach(Order::delete);
         orderRepository.saveAll(orders);
 	}

--- a/src/main/java/com/sparta/outsourcing/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/service/MemberService.java
@@ -83,9 +83,9 @@ public class MemberService {
 
         member.delete();
 
-        List<Store> stores = storeRepository.findAllByMember(member);
+        List<Store> stores = storeRepository.findAllByActiveMember(member);
         stores.forEach(store -> {
-            List<Menu> menus = menuRepository.findAllByStore(store);
+            List<Menu> menus = menuRepository.findAllByActiveStore(store);
             menus.forEach(Menu::delete);
             menuRepository.saveAll(menus);
             store.delete();
@@ -93,7 +93,7 @@ public class MemberService {
         );
         storeRepository.saveAll(stores);
 
-        List<Order> orders = orderRepository.findAllByMember(member);
+        List<Order> orders = orderRepository.findAllByActiveMember(member);
         orders.forEach(Order::delete);
         orderRepository.saveAll(orders);
 	}

--- a/src/main/java/com/sparta/outsourcing/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/outsourcing/domain/menu/entity/Menu.java
@@ -33,7 +33,7 @@ public class Menu extends TimeStamped {
 	private int price;
 
 	@Column(nullable = false)
-	private boolean isDeleted = false;
+	private boolean delete;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "storeId", nullable = false)
@@ -42,7 +42,7 @@ public class Menu extends TimeStamped {
 	public Menu(String menuName, int price, Store store) {
 		this.menuName = menuName;
 		this.price = price;
-		this.isDeleted = false;
+		this.delete = false;
 		this.store = store;
 	}
 
@@ -56,6 +56,6 @@ public class Menu extends TimeStamped {
 	}
 
 	public void delete() {
-		this.isDeleted = true;
+		this.delete = true;
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/menu/repository/MenuRepository.java
@@ -5,11 +5,18 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sparta.outsourcing.domain.menu.entity.Menu;
 import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
-	Page<Menu> findAllByStoreContaining(Store store, Pageable menuPageable);
 	List<Menu> findAllByStore(Store store);
+
+	@Query("SELECT m FROM Menu m WHERE m.store = :store AND m.isDeleted = false")
+	List<Menu> findAllByActiveStore(Store store);
+
+	@Query("SELECT m FROM Menu m WHERE m.store = :store AND m.isDeleted = false")
+	Page<Menu> findAllByActiveStore(Store store, Pageable menuPageable);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/menu/repository/MenuRepository.java
@@ -5,18 +5,11 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.sparta.outsourcing.domain.menu.entity.Menu;
 import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
-	List<Menu> findAllByStore(Store store);
-
-	@Query("SELECT m FROM Menu m WHERE m.store = :store AND m.isDeleted = false")
-	List<Menu> findAllByActiveStore(Store store);
-
-	@Query("SELECT m FROM Menu m WHERE m.store = :store AND m.isDeleted = false")
-	Page<Menu> findAllByActiveStore(Store store, Pageable menuPageable);
+	Page<Menu> findAllByStoreAndDeleteFalse(Store store, Pageable menuPageable);
+	List<Menu> findAllByStoreAndDeleteFalse(Store store);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/menu/service/MenuService.java
@@ -28,7 +28,7 @@ public class MenuService {
 			throw new IllegalArgumentException("해당 기능은 사장님만 가능합니다");
 		}
 
-		if (store.isDeleted()) {
+		if (store.isDelete()) {
 			throw new IllegalArgumentException("폐업한 가게입니다");
 		}
 
@@ -45,7 +45,7 @@ public class MenuService {
 			throw new IllegalArgumentException("남의 가게 정보는 수정할 수 없습니다");
 		}
 
-		if (store.isDeleted()) {
+		if (store.isDelete()) {
 			throw new IllegalArgumentException("폐업한 가게입니다");
 		}
 
@@ -53,7 +53,7 @@ public class MenuService {
 			throw new IllegalArgumentException("해당 기능은 사장님만 가능합니다");
 		}
 
-		if(menu.isDeleted()) {
+		if(menu.isDelete()) {
 			throw new IllegalArgumentException("이미 삭제된 메뉴입니다");
 		}
 
@@ -70,7 +70,7 @@ public class MenuService {
 			throw new IllegalArgumentException("해당 기능은 사장님만 가능합니다");
 		}
 
-		if(menu.isDeleted()) {
+		if(menu.isDelete()) {
 			throw new IllegalArgumentException("이미 삭제된 메뉴입니다");
 		}
 

--- a/src/main/java/com/sparta/outsourcing/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/outsourcing/domain/order/entity/Order.java
@@ -46,7 +46,7 @@ public class Order extends TimeStamped {
 	private Menu menu;
 
 	@Column(nullable = false)
-	private boolean isDeleted;
+	private boolean delete;
 
 	// 주문 생성자: 필수 필드 초기화
 	private Order(Member member, Store store, Menu menu) {
@@ -54,7 +54,7 @@ public class Order extends TimeStamped {
 		this.store = store;
 		this.menu = menu;
 		this.status = OrderStatus.PENDING;
-		this.isDeleted = false;
+		this.delete = false;
 	}
 
 	public static Order createOf(Member member, Store store, Menu menu) {
@@ -62,6 +62,6 @@ public class Order extends TimeStamped {
 	}
 
 	public void delete() {
-		this.isDeleted = true;
+		this.delete = true;
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/order/repository/OrderRepository.java
@@ -3,14 +3,10 @@ package com.sparta.outsourcing.domain.order.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.order.entity.Order;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-	List<Order> findAllByMember(Member member);
-
-	@Query("SELECT o FROM Order o WHERE o.member = :member AND o.isDeleted = false")
-	List<Order> findAllByActiveMember(Member member);
+	List<Order> findAllByMemberAndDeleteFalse(Member member);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/order/repository/OrderRepository.java
@@ -3,10 +3,14 @@ package com.sparta.outsourcing.domain.order.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.order.entity.Order;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 	List<Order> findAllByMember(Member member);
+
+	@Query("SELECT o FROM Order o WHERE o.member = :member AND o.isDeleted = false")
+	List<Order> findAllByActiveMember(Member member);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/order/service/OrderService.java
@@ -39,7 +39,7 @@ public class OrderService {
 			() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다.")
 		);
 
-		if (store.isDeleted()) {
+		if (store.isDelete()) {
 			throw new IllegalArgumentException("폐업한 가게입니다.");
 		}
 
@@ -52,7 +52,7 @@ public class OrderService {
 			() -> new IllegalArgumentException("해당 메뉴를 찾을 수 없습니다.")
 		);
 
-		if (menu.isDeleted()) {
+		if (menu.isDelete()) {
 			throw new IllegalArgumentException("선택한 메뉴는 현재 주문할 수 없습니다.");
 		}
 

--- a/src/main/java/com/sparta/outsourcing/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/entity/Review.java
@@ -40,11 +40,11 @@ public class Review extends TimeStamped {
 	@JoinColumn(name = "orderId", nullable = false)
 	private Order order;
 
-	private boolean isDeleted;
+	private boolean delete;
 
 	private Review(int rating) {
 		this.rating = rating;
-		this.isDeleted = false;
+		this.delete = false;
 	}
 
 	public static Review createOf(int rating) {

--- a/src/main/java/com/sparta/outsourcing/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/entity/Review.java
@@ -40,8 +40,11 @@ public class Review extends TimeStamped {
 	@JoinColumn(name = "orderId", nullable = false)
 	private Order order;
 
+	private boolean isDeleted;
+
 	private Review(int rating) {
 		this.rating = rating;
+		this.isDeleted = false;
 	}
 
 	public static Review createOf(int rating) {

--- a/src/main/java/com/sparta/outsourcing/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/repository/ReviewRepository.java
@@ -4,11 +4,16 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sparta.outsourcing.domain.review.entity.Review;
 import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-	Page<Review> findAllByStoreContaining(Store store, Pageable reviewPageable);
 	Optional<Object> findByOrderId(Long orderId);
+
+	@Query("SELECT r FROM Review r WHERE r.store = :store AND r.isDeleted = false")
+	Page<Review> findAllByActiveStore(Store store, Pageable reviewPageable);
 }
+

--- a/src/main/java/com/sparta/outsourcing/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/repository/ReviewRepository.java
@@ -1,11 +1,10 @@
 package com.sparta.outsourcing.domain.review.repository;
 
 import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.sparta.outsourcing.domain.review.entity.Review;
 import com.sparta.outsourcing.domain.store.entity.Store;
@@ -13,7 +12,6 @@ import com.sparta.outsourcing.domain.store.entity.Store;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 	Optional<Object> findByOrderId(Long orderId);
 
-	@Query("SELECT r FROM Review r WHERE r.store = :store AND r.isDeleted = false")
-	Page<Review> findAllByActiveStore(Store store, Pageable reviewPageable);
+	Page<Review> findAllByStoreAndDeleteFalse(Store store, Pageable reviewPageable);
 }
 

--- a/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
@@ -41,10 +41,10 @@ public class Store extends TimeStamped {
 	private int minPrice;
 
 	@Column(nullable = false)
-	private boolean isOpened;
+	private boolean open;
 
 	@Column(nullable = false)
-	private boolean isDeleted;
+	private boolean delete;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
@@ -57,8 +57,8 @@ public class Store extends TimeStamped {
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.minPrice = minPrice;
-		this.isOpened = false;
-		this.isDeleted = false;
+		this.open = false;
+		this.delete = false;
 		this.member = member;
 	}
 
@@ -70,10 +70,10 @@ public class Store extends TimeStamped {
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.minPrice = minPrice;
-		this.isOpened = opened;
+		this.open = opened;
 	}
 
 	public void delete() {
-		this.isDeleted = true;
+		this.delete = true;
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
@@ -5,12 +5,20 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
-	int countAllByMemberAndIsDeletedFalse(Member storeOwner);
-	Page<Store> findAllByStoreNameContaining(String storeName, Pageable pageable);
-	List<Store> findAllByMember(Member member);
+	Page<Store> findAllAndIsDeletedFalse(Pageable pageable);
+
+	@Query("SELECT COUNT(s) FROM Store s WHERE s.member = :member AND s.isDeleted = false")
+	int countActiveStoresByMember(Member storeOwner);
+
+	@Query("SELECT s FROM Store s WHERE s.storeName LIKE %:storeName% AND s.isDeleted = false")
+	Page<Store> findAllByStoreNameContainingAndIsDeletedFalse(String storeName, Pageable pageable);
+
+	@Query("SELECT s FROM Store s WHERE s.member = :member AND s.isDeleted = false")
+	List<Store> findAllByActiveMember(Member member);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
@@ -5,20 +5,13 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
-	Page<Store> findAllAndIsDeletedFalse(Pageable pageable);
-
-	@Query("SELECT COUNT(s) FROM Store s WHERE s.member = :member AND s.isDeleted = false")
-	int countActiveStoresByMember(Member storeOwner);
-
-	@Query("SELECT s FROM Store s WHERE s.storeName LIKE %:storeName% AND s.isDeleted = false")
-	Page<Store> findAllByStoreNameContainingAndIsDeletedFalse(String storeName, Pageable pageable);
-
-	@Query("SELECT s FROM Store s WHERE s.member = :member AND s.isDeleted = false")
-	List<Store> findAllByActiveMember(Member member);
+	Page<Store> findAllByDeleteFalse(Pageable pageable);
+	List<Store> findAllByMemberAndDeleteFalse(Member member);
+	int countAllByMemberAndDeleteFalse(Member storeOwner);
+	Page<Store> findAllByStoreNameContainingAndDeleteFalse(String storeName, Pageable pageable);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
@@ -46,7 +46,7 @@ public class StoreService {
 			throw new IllegalArgumentException("사장님 권한 회원만 가게를 생성할 수 있습니다.");
 		}
 
-		if (storeRepository.countActiveStoresByMember(storeOwner) == 3) {
+		if (storeRepository.countAllByMemberAndDeleteFalse(storeOwner) == 3) {
 			throw new IllegalArgumentException("해당 사장님은 이미 3개의 가게를 소유하고 있습니다.");
 		}
 
@@ -58,13 +58,13 @@ public class StoreService {
 
 	public Page<ShortStoreResponseDto> getAllStoreByName(String storeName, int page) {
 		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
-		Page<Store> stores = storeRepository.findAllByStoreNameContainingAndIsDeletedFalse(storeName, pageable);
+		Page<Store> stores = storeRepository.findAllByStoreNameContainingAndDeleteFalse(storeName, pageable);
 		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
 	}
 
 	public Page<ShortStoreResponseDto> getAllStore(int page) {
 		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
-		Page<Store> stores = storeRepository.findAllAndIsDeletedFalse(pageable);
+		Page<Store> stores = storeRepository.findAllByDeleteFalse(pageable);
 		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
 	}
 
@@ -74,10 +74,10 @@ public class StoreService {
 		);
 
 		Pageable menuPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
-		Page<Menu> menus = menuRepository.findAllByActiveStore(store, menuPageable);
+		Page<Menu> menus = menuRepository.findAllByStoreAndDeleteFalse(store, menuPageable);
 
 		Pageable reviewPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
-		Page<Review> reviews = reviewRepository.findAllByActiveStore(store, reviewPageable);
+		Page<Review> reviews = reviewRepository.findAllByStoreAndDeleteFalse(store, reviewPageable);
 
 		return new DetailedStoreResponseDto(
 			store,
@@ -91,7 +91,7 @@ public class StoreService {
 			() -> new IllegalArgumentException("해당하는 가게가 없습니다.")
 		);
 
-		if (store.isDeleted()) {
+		if (store.isDelete()) {
 			throw new IllegalArgumentException("폐업한 가게입니다.");
 		}
 
@@ -113,7 +113,7 @@ public class StoreService {
 			() -> new IllegalArgumentException("해당하는 가게가 없습니다.")
 		);
 
-		if (store.isDeleted()) {
+		if (store.isDelete()) {
 			throw new IllegalArgumentException("이미 폐업한 가게입니다.");
 		}
 
@@ -127,7 +127,7 @@ public class StoreService {
 
 		store.delete();
 
-		List<Menu> menus = menuRepository.findAllByActiveStore(store);
+		List<Menu> menus = menuRepository.findAllByStoreAndDeleteFalse(store);
 		menus.forEach(Menu::delete);
 		menuRepository.saveAll(menus);
 	}

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
@@ -46,7 +46,7 @@ public class StoreService {
 			throw new IllegalArgumentException("사장님 권한 회원만 가게를 생성할 수 있습니다.");
 		}
 
-		if (storeRepository.countAllByMemberAndIsDeletedFalse(storeOwner) == 3) {
+		if (storeRepository.countActiveStoresByMember(storeOwner) == 3) {
 			throw new IllegalArgumentException("해당 사장님은 이미 3개의 가게를 소유하고 있습니다.");
 		}
 
@@ -58,13 +58,13 @@ public class StoreService {
 
 	public Page<ShortStoreResponseDto> getAllStoreByName(String storeName, int page) {
 		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
-		Page<Store> stores = storeRepository.findAllByStoreNameContaining(storeName, pageable);
+		Page<Store> stores = storeRepository.findAllByStoreNameContainingAndIsDeletedFalse(storeName, pageable);
 		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
 	}
 
 	public Page<ShortStoreResponseDto> getAllStore(int page) {
 		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
-		Page<Store> stores = storeRepository.findAll(pageable);
+		Page<Store> stores = storeRepository.findAllAndIsDeletedFalse(pageable);
 		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
 	}
 
@@ -74,10 +74,10 @@ public class StoreService {
 		);
 
 		Pageable menuPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
-		Page<Menu> menus = menuRepository.findAllByStoreContaining(store, menuPageable);
+		Page<Menu> menus = menuRepository.findAllByActiveStore(store, menuPageable);
 
 		Pageable reviewPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
-		Page<Review> reviews = reviewRepository.findAllByStoreContaining(store, reviewPageable);
+		Page<Review> reviews = reviewRepository.findAllByActiveStore(store, reviewPageable);
 
 		return new DetailedStoreResponseDto(
 			store,
@@ -127,7 +127,7 @@ public class StoreService {
 
 		store.delete();
 
-		List<Menu> menus = menuRepository.findAllByStore(store);
+		List<Menu> menus = menuRepository.findAllByActiveStore(store);
 		menus.forEach(Menu::delete);
 		menuRepository.saveAll(menus);
 	}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게 수정했나보다 무엇을 왜 수정했는지 설명해주세요. -->
조회할 때 isDeleted가 true인 데이터는 조회하지 않도록 모든 JPQL을 수정했습니다. 아직 테스트는 해보지 못했어요. 
<!---- Resolves: fix/emergency -->

## PR 유형
어떤 변경 사항이 있나요?

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).