### PR TITLE
feat: 가게 즐겨찾기 기능 추가 [도전]

### DIFF
--- a/src/main/java/com/sparta/outsourcing/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/outsourcing/common/exception/GlobalExceptionHandler.java
@@ -75,6 +75,14 @@ public class GlobalExceptionHandler {
                 .body(makeResponseExceptionCode(exceptionCode));
     }
 
+    @ExceptionHandler(LikeExceptions.class)
+    public ResponseEntity<Object> handleLikeExceptions(LikeExceptions e) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}: {}", exceptionCode, exceptionCode.getMessage());
+        return ResponseEntity.status(exceptionCode.getHttpStatus())
+            .body(makeResponseExceptionCode(exceptionCode));
+    }
+
     @ExceptionHandler(HasNotPermissionException.class)
     public ResponseEntity<Object> handleHasNotPermissionException(HasNotPermissionException e) {
         ExceptionCode exceptionCode = e.getExceptionCode();

--- a/src/main/java/com/sparta/outsourcing/common/exception/customException/LikeExceptions.java
+++ b/src/main/java/com/sparta/outsourcing/common/exception/customException/LikeExceptions.java
@@ -1,0 +1,14 @@
+package com.sparta.outsourcing.common.exception.customException;
+
+import com.sparta.outsourcing.common.exception.enums.ExceptionCode;
+
+import lombok.Getter;
+
+@Getter
+public class LikeExceptions extends RuntimeException {
+	private final ExceptionCode exceptionCode;
+
+	public LikeExceptions(ExceptionCode exceptionCode) {
+		this.exceptionCode = exceptionCode;
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/sparta/outsourcing/common/exception/enums/ExceptionCode.java
@@ -12,6 +12,7 @@ public enum ExceptionCode {
     NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "이름은 최대 4글자까지 가능합니다"),
     USERNAME_REQUIRED(HttpStatus.BAD_REQUEST, "이름이 누락되었습니다"),
     MEMBER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 회원입니다"),
+    ADDRESS_REQUIRED(HttpStatus.BAD_REQUEST, "주소가 누락되었습니다"),
 
     //이메일
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "해당 이메일이 존재합니다"),

--- a/src/main/java/com/sparta/outsourcing/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/sparta/outsourcing/common/exception/enums/ExceptionCode.java
@@ -62,9 +62,9 @@ public enum ExceptionCode {
     HAS_NOT_PERMISSION(HttpStatus.FORBIDDEN, "권한이 없습니다"),
     ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "OWNER과 USER중 하나를 입력하세요"),
 
-
-
-
+    //----------즐겨찾기----------
+    ALREADY_LIKE_EXISTS(HttpStatus.BAD_REQUEST, "이미 즐겨찾기한 가게입니다"),
+    NOT_FOUND_LIKE(HttpStatus.NOT_FOUND, "이미 즐겨찾기한 가게입니다"),
 
     //토큰
     NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "인증 토큰이 잘못되었거나 누락되었습니다"),

--- a/src/main/java/com/sparta/outsourcing/domain/like/controller/LikeController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/like/controller/LikeController.java
@@ -1,0 +1,41 @@
+package com.sparta.outsourcing.domain.like.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.outsourcing.domain.like.dto.StoreLikeRequestDto;
+import com.sparta.outsourcing.domain.like.service.LikeService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores")
+public class LikeController {
+
+	private final LikeService likeService;
+
+	@PostMapping("/like")
+	public ResponseEntity<Void> likeStore(
+		@RequestBody StoreLikeRequestDto requestDto,
+		@RequestAttribute("id") Long memberId
+	) {
+		likeService.likeStore(requestDto, memberId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/unlike")
+	public ResponseEntity<Void> unlikeStore(
+		@RequestBody StoreLikeRequestDto requestDto,
+		@RequestAttribute("id") Long memberId
+	) {
+		likeService.unlikeStore(requestDto, memberId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/like/dto/StoreLikeRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/like/dto/StoreLikeRequestDto.java
@@ -1,0 +1,12 @@
+package com.sparta.outsourcing.domain.like.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreLikeRequestDto {
+	@NotNull(message = "가게 id는 빈 값일 수 없습니다.")
+	private Long storeId;
+}

--- a/src/main/java/com/sparta/outsourcing/domain/like/entity/Like.java
+++ b/src/main/java/com/sparta/outsourcing/domain/like/entity/Like.java
@@ -1,0 +1,42 @@
+package com.sparta.outsourcing.domain.like.entity;
+
+import com.sparta.outsourcing.domain.member.entity.Member;
+import com.sparta.outsourcing.domain.store.entity.Store;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "likes")
+@NoArgsConstructor
+public class Like {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id", nullable = false)
+	private Store store;
+
+	private Like(Member member, Store store) {
+		this.member = member;
+		this.store = store;
+	}
+
+	public static Like createOf(Member member, Store store) {
+		return new Like(member, store);
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/like/repository/LikeRepository.java
@@ -1,0 +1,26 @@
+package com.sparta.outsourcing.domain.like.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.sparta.outsourcing.domain.like.entity.Like;
+import com.sparta.outsourcing.domain.member.entity.Member;
+import com.sparta.outsourcing.domain.store.entity.Store;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+	Optional<Like> findByMemberAndStore(Member member, Store store);
+
+	@Query("SELECT l.store FROM Like l WHERE l.member = :member AND l.store.inactive = false ORDER BY l.store.modifiedAt DESC")
+	List<Store> findStoresByMemberAndInactiveFalseOrderByModifiedAtDesc(@Param("member") Member member);
+
+	@Query("SELECT l.store FROM Like l WHERE l.member = :member AND l.store.inactive = false AND l.store.storeName LIKE %:storeName% ORDER BY l.store.modifiedAt DESC")
+	List<Store> findStoresByMemberAndInactiveFalseAndStoreNameContainingOrderByModifiedAtDesc(@Param("member") Member member, @Param("storeName") String storeName);
+
+	List<Like> findAllByMemberAndStore(Member member, Store store);
+}

--- a/src/main/java/com/sparta/outsourcing/domain/like/service/LikeService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/like/service/LikeService.java
@@ -1,0 +1,65 @@
+package com.sparta.outsourcing.domain.like.service;
+
+import static com.sparta.outsourcing.common.exception.enums.ExceptionCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.sparta.outsourcing.common.exception.customException.LikeExceptions;
+import com.sparta.outsourcing.domain.like.dto.StoreLikeRequestDto;
+import com.sparta.outsourcing.domain.like.entity.Like;
+import com.sparta.outsourcing.domain.like.repository.LikeRepository;
+import com.sparta.outsourcing.domain.member.entity.Member;
+import com.sparta.outsourcing.domain.member.repository.MemberRepository;
+import com.sparta.outsourcing.domain.store.entity.Store;
+import com.sparta.outsourcing.domain.store.repository.StoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+	private final LikeRepository likeRepository;
+	private final MemberRepository memberRepository;
+	private final StoreRepository storeRepository;
+
+	public void likeStore(StoreLikeRequestDto requestDto, Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new LikeExceptions(NOT_FOUND_USER)
+		);
+
+		Store store = storeRepository.findById(requestDto.getStoreId()).orElseThrow(
+			() -> new LikeExceptions(NOT_FOUND_STORE)
+		);
+
+		List<Like> existLike = likeRepository.findAllByMemberAndStore(member, store);
+		if (!existLike.isEmpty()) {
+			throw new LikeExceptions(ALREADY_LIKE_EXISTS);
+		}
+
+		if (store.isInactive()) {
+			throw new LikeExceptions(STORE_OUT_OF_BUSINESS);
+		}
+
+		Like like = Like.createOf(member, store);
+		likeRepository.save(like);
+	}
+
+	public void unlikeStore(StoreLikeRequestDto requestDto, Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new LikeExceptions(NOT_FOUND_USER)
+		);
+
+		Store store = storeRepository.findById(requestDto.getStoreId()).orElseThrow(
+			() -> new LikeExceptions(NOT_FOUND_STORE)
+		);
+
+		Like like = likeRepository.findByMemberAndStore(member, store).orElseThrow(
+			() -> new LikeExceptions(NOT_FOUND_LIKE)
+		);
+
+		likeRepository.delete(like);
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -41,7 +42,7 @@ public class MemberController {
         memberService.login(requestDto, response);
     }
 
-    @DeleteMapping("/members/{memberId}")
+    @DeleteMapping("/members")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteMember(
         @RequestBody DeleteMemberRequestDto requestDto,
@@ -50,7 +51,7 @@ public class MemberController {
         memberService.deleteMember(requestDto, memberId);
     }
 
-    @PutMapping("/members/{memberId}")
+    @PutMapping("/members")
     public void updateMember(
         @RequestBody @Valid UpdateMemberRequestDto requestDto,
         @RequestAttribute("id") Long memberId

--- a/src/main/java/com/sparta/outsourcing/domain/member/dto/DeleteMemberRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/dto/DeleteMemberRequestDto.java
@@ -4,5 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class DeleteMemberRequestDto {
+	private Long memberId;
 	private String oldPassword;
 }

--- a/src/main/java/com/sparta/outsourcing/domain/member/dto/UpdateMemberRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/dto/UpdateMemberRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 @Getter
 public class UpdateMemberRequestDto {
+	private Long memberId;
 	private String username;
 	@NotNull(message = "비밀번호를 입력하세요")
 	private String oldPassword;

--- a/src/main/java/com/sparta/outsourcing/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/entity/Member.java
@@ -61,14 +61,8 @@ public class Member extends TimeStamped {
 	}
 
 	public void update(String username, String password, String address) {
-		if (username != null && !username.isEmpty()) {
 			this.username = username;
-		}
-		if (password != null && !username.isEmpty()) {
 			this.password = password;
-		}
-		if (address != null && !username.isEmpty()) {
 			this.address = address;
-		}
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/member/service/MemberService.java
@@ -69,9 +69,13 @@ public class MemberService {
 	}
 
 	public void deleteMember(DeleteMemberRequestDto requestDto, Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Member member = memberRepository.findById(requestDto.getMemberId()).orElseThrow(
             () -> new MemberExceptions(NOT_FOUND_USER)
         );
+
+        if (!requestDto.getMemberId().equals(memberId)) {
+            throw new MemberExceptions(HAS_NOT_PERMISSION);
+        }
 
         if (!passwordEncoder.matches(requestDto.getOldPassword(), member.getPassword())) {
             throw new MemberExceptions(NOT_MATCH_PASSWORD);
@@ -100,9 +104,14 @@ public class MemberService {
 
     @Transactional
     public void updateMember(UpdateMemberRequestDto requestDto, Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Member member = memberRepository.findById(requestDto.getMemberId()).orElseThrow(
             () -> new MemberExceptions(NOT_FOUND_USER)
         );
+
+        if (!requestDto.getMemberId().equals(memberId)) {
+            throw new MemberExceptions(HAS_NOT_PERMISSION);
+        }
+
         if (!passwordEncoder.matches(requestDto.getOldPassword(), member.getPassword())) {
             throw new MemberExceptions(NOT_MATCH_PASSWORD);
         }
@@ -111,6 +120,14 @@ public class MemberService {
 
         if (requestDto.getNewPassword() != null && !requestDto.getNewPassword().isEmpty()) {
             encodedPassword = passwordEncoder.encode(requestDto.getNewPassword());
+        }
+
+        if (requestDto.getUsername() == null || requestDto.getUsername().isEmpty()) {
+            throw new MemberExceptions(USERNAME_REQUIRED);
+        }
+
+        if (requestDto.getAddress() == null || requestDto.getAddress().isEmpty()) {
+            throw new MemberExceptions(ADDRESS_REQUIRED);
         }
 
         member.update(requestDto.getUsername(), encodedPassword, requestDto.getAddress());

--- a/src/main/java/com/sparta/outsourcing/domain/review/dto/ReviewUpdateRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/review/dto/ReviewUpdateRequestDto.java
@@ -7,4 +7,8 @@ import lombok.Getter;
 public class ReviewUpdateRequestDto {
 	@NotNull(message = "숫자를 입력해주세요.")
 	private int rating;
+
+	public ReviewUpdateRequestDto(int rating) {
+		this.rating = rating;
+	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/controller/StoreController.java
@@ -1,5 +1,8 @@
 package com.sparta.outsourcing.domain.store.controller;
 
+import java.util.List;
+
+import org.apache.coyote.Request;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,14 +46,15 @@ public class StoreController {
 	}
 
 	@GetMapping("")
-	public ResponseEntity<Page<ShortStoreResponseDto>> getStore(
+	public ResponseEntity<List<ShortStoreResponseDto>> getStore(
 		@RequestParam(required = false) String storeName,
-		@RequestParam(defaultValue = "0") int page
+		@RequestParam(defaultValue = "0") int page,
+		@RequestAttribute("id") Long memberId
 	) {
 		if (storeName != null && !storeName.isEmpty()) {
-			return ResponseEntity.status(HttpStatus.OK).body(storeService.getAllStoreByName(storeName, page));
+			return ResponseEntity.status(HttpStatus.OK).body(storeService.getAllStoreByName(storeName, page, memberId));
 		}
-		return ResponseEntity.status(HttpStatus.OK).body(storeService.getAllStore(page));
+		return ResponseEntity.status(HttpStatus.OK).body(storeService.getAllStore(page, memberId));
 	}
 
 

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/ShortStoreResponseDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/ShortStoreResponseDto.java
@@ -1,5 +1,7 @@
 package com.sparta.outsourcing.domain.store.dto;
 
+import com.sparta.outsourcing.domain.store.entity.Store;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,8 +11,8 @@ public class ShortStoreResponseDto {
 	private Long id;
 	private String storeName;
 
-	public ShortStoreResponseDto(Long id, String storeName) {
-		this.id = id;
-		this.storeName = storeName;
+	public ShortStoreResponseDto(Store store) {
+		this.id = store.getId();
+		this.storeName = store.getStoreName();
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/StoreRequestDto.java
@@ -5,6 +5,7 @@ import java.sql.Time;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class StoreRequestDto {
@@ -19,4 +20,11 @@ public class StoreRequestDto {
 
 	@Positive(message = "최소 금액은 음수가 아닙니다.")
 	private int minPrice;
+
+	public StoreRequestDto(String storeName, Time openTime, Time closeTime, int minPrice) {
+		this.storeName = storeName;
+		this.openTime = openTime;
+		this.closeTime = closeTime;
+		this.minPrice = minPrice;
+	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/StoreUpdateRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/StoreUpdateRequestDto.java
@@ -17,5 +17,5 @@ public class StoreUpdateRequestDto {
 	@Positive(message = "최소 금액은 음수가 아닙니다.")
 	private int minPrice;
 
-	private boolean isOpened;
+	private boolean open;
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
@@ -14,8 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
@@ -57,7 +57,7 @@ public class Store extends TimeStamped {
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.minPrice = minPrice;
-		this.open = false;
+		this.open = true;
 		this.inactive = false;
 		this.member = member;
 	}

--- a/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/repository/StoreRepository.java
@@ -10,8 +10,8 @@ import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.store.entity.Store;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
-	Page<Store> findAllByInactiveFalse(Pageable pageable);
 	List<Store> findAllByMemberAndInactiveFalse(Member member);
 	int countAllByMemberAndInactiveFalse(Member storeOwner);
-	Page<Store> findAllByStoreNameContainingAndInactiveFalse(String storeName, Pageable pageable);
+	Page<Store> findAllByInactiveFalseAndIdNotIn(List<Long> likedStoreIds, Pageable pageable);
+	Page<Store> findAllByInactiveFalseAndStoreNameContainingAndIdNotIn(String storeName, List<Long> likedStoresWithNameIds, Pageable pageable);
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
@@ -2,7 +2,10 @@ package com.sparta.outsourcing.domain.store.service;
 
 import static com.sparta.outsourcing.common.exception.enums.ExceptionCode.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.outsourcing.common.exception.customException.StoreExceptions;
+import com.sparta.outsourcing.domain.like.repository.LikeRepository;
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.member.entity.MemberRole;
 import com.sparta.outsourcing.domain.member.repository.MemberRepository;
@@ -41,6 +45,7 @@ public class StoreService {
 	private final MemberRepository memberRepository;
 	private final MenuRepository menuRepository;
 	private final ReviewRepository reviewRepository;
+	private final LikeRepository likeRepository;
 
 	public StoreResponseDto createStore(StoreRequestDto requestDto, Long memberId) {
 		Member storeOwner = memberRepository.findById(memberId).orElseThrow(
@@ -61,16 +66,36 @@ public class StoreService {
 		return new StoreResponseDto(savedStore);
 	}
 
-	public Page<ShortStoreResponseDto> getAllStoreByName(String storeName, int page) {
+	public List<ShortStoreResponseDto> getAllStoreByName(String storeName, int page, Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new StoreExceptions(NOT_FOUND_USER)
+		);
+
 		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
-		Page<Store> stores = storeRepository.findAllByStoreNameContainingAndInactiveFalse(storeName, pageable);
-		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
+
+		List<Store> likedStoresWithName = likeRepository.findStoresByMemberAndInactiveFalseAndStoreNameContainingOrderByModifiedAtDesc(member, storeName);
+		List<Long> likedStoresWithNameIds = likedStoresWithName.stream().map(Store::getId).toList();
+
+		Page<Store> generalStoresWithName = storeRepository.findAllByInactiveFalseAndStoreNameContainingAndIdNotIn(storeName, likedStoresWithNameIds, pageable);
+
+		return Stream.concat(likedStoresWithName.stream(), generalStoresWithName.getContent().stream())
+			.map(ShortStoreResponseDto::new).toList();
 	}
 
-	public Page<ShortStoreResponseDto> getAllStore(int page) {
+	public List<ShortStoreResponseDto> getAllStore(int page, Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new StoreExceptions(NOT_FOUND_USER)
+		);
+
 		Pageable pageable = PageRequest.of(page, 5, Sort.by("modifiedAt").descending());
-		Page<Store> stores = storeRepository.findAllByInactiveFalse(pageable);
-		return stores.map(store -> new ShortStoreResponseDto(store.getId(), store.getStoreName()));
+
+		List<Store> likedStores = likeRepository.findStoresByMemberAndInactiveFalseOrderByModifiedAtDesc(member);
+		List<Long> likedStoreIds = likedStores.stream().map(Store::getId).toList();
+
+		Page<Store> generalStores = storeRepository.findAllByInactiveFalseAndIdNotIn(likedStoreIds, pageable);
+
+		return Stream.concat(likedStores.stream(), generalStores.getContent().stream())
+			.map(ShortStoreResponseDto::new).toList();
 	}
 
 	public DetailedStoreResponseDto getOneStore(Long storeId) {
@@ -109,7 +134,7 @@ public class StoreService {
 			throw new StoreExceptions(ONLY_OWNER_ALLOWED);
 		}
 
-		store.update(requestDto.getOpenTime(), requestDto.getCloseTime(), requestDto.getMinPrice(), requestDto.isOpened());
+		store.update(requestDto.getOpenTime(), requestDto.getCloseTime(), requestDto.getMinPrice(), requestDto.isOpen());
 
 		return new StoreResponseDto(store);
 	}

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
@@ -55,9 +55,9 @@ public class StoreService {
 		}
 
 		Store store = Store.createOf(requestDto.getStoreName(), requestDto.getOpenTime(), requestDto.getCloseTime(), requestDto.getMinPrice(), storeOwner);
-		storeRepository.save(store);
+		Store savedStore = storeRepository.save(store);
 
-		return new StoreResponseDto(store);
+		return new StoreResponseDto(savedStore);
 	}
 
 	public Page<ShortStoreResponseDto> getAllStoreByName(String storeName, int page) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,9 @@
 spring.application.name=outsourcing
 
 spring.datasource.url=jdbc:mysql://localhost:3306/outsourcing
+
 spring.datasource.username=root
-spring.datasource.password=00000000
+spring.datasource.password=tngr53mn
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true

--- a/src/test/java/com/sparta/outsourcing/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,107 @@
+package com.sparta.outsourcing.domain.review.service;
+
+import static com.sparta.outsourcing.common.exception.enums.ExceptionCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Time;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sparta.outsourcing.common.exception.customException.ReviewExceptions;
+import com.sparta.outsourcing.domain.member.entity.Member;
+import com.sparta.outsourcing.domain.member.entity.MemberRole;
+import com.sparta.outsourcing.domain.member.repository.MemberRepository;
+import com.sparta.outsourcing.domain.menu.entity.Menu;
+import com.sparta.outsourcing.domain.order.entity.Order;
+import com.sparta.outsourcing.domain.order.entity.OrderStatus;
+import com.sparta.outsourcing.domain.order.repository.OrderRepository;
+import com.sparta.outsourcing.domain.review.dto.ReviewRequestDto;
+import com.sparta.outsourcing.domain.review.dto.ReviewResponseDto;
+import com.sparta.outsourcing.domain.review.dto.ReviewUpdateRequestDto;
+import com.sparta.outsourcing.domain.review.entity.Review;
+import com.sparta.outsourcing.domain.review.repository.ReviewRepository;
+import com.sparta.outsourcing.domain.store.entity.Store;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+	@InjectMocks
+	private ReviewService reviewService;
+	@Mock
+	private ReviewRepository reviewRepository;
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	private Order order;
+	private Member member;
+	private Store store;
+	private Menu menu;
+
+	@BeforeEach
+	void setUp() {
+		//리뷰를 달 멤버생성
+		member = Member.createOf("testUser", "1234Qwer!", "test@example.com", "Seoul", MemberRole.USER);
+		store = Store.createOf("testStore", Time.valueOf("09:00:00"), Time.valueOf("21:00:00"),100,member);
+		menu = Menu.createOf("testMenu", 10000, store);
+		order = Order.createOf(member, store, menu, 1);
+		ReflectionTestUtils.setField(member, "id", 1L);
+		ReflectionTestUtils.setField(order,"id", 1L);
+	}
+
+	@Test
+	@DisplayName("리뷰가 정상적으로 작성되는지 테스트")
+	void createReviewTest() {
+		//given
+		Long memberId = member.getId();
+		Long orderId = order.getId();
+		ReviewRequestDto reviewRequestDto = new ReviewRequestDto();
+		ReflectionTestUtils.setField(reviewRequestDto, "memberId", memberId);
+		ReflectionTestUtils.setField(reviewRequestDto, "orderId", orderId);
+		ReflectionTestUtils.setField(reviewRequestDto, "rating", 4);
+		ReflectionTestUtils.setField(order,"status", OrderStatus.COMPLETED);
+		//Order member 존재하는 하고 이미 작성된 리뷰가 없는경우
+		when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+		when(reviewRepository.findByOrderId(1L)).thenReturn(Optional.empty());
+		//when
+		ReviewResponseDto reviewResponseDto = reviewService.createReview(reviewRequestDto, 1L);
+		//then
+		assertNotNull(reviewResponseDto); //null 이 아니어야됨
+		assertEquals(4, reviewResponseDto.getRating()); // 지정한 4점이어야됨
+		assertEquals(orderId, reviewResponseDto.getOrderId()); //주문아이디가 입력한 값과 같아야됨
+	}
+
+	@Test
+	@DisplayName("권한확인 - 리뷰 수정 실패 테스트")
+	void updateReviewFailTest_Unauthorized() {
+		//given
+		Long reviewId = 1L;
+		Long requestMemberId = 2L; // 수정을 요청하는 사람의 memberId
+
+		Review existingReview = Review.createOf(4, order);
+		ReflectionTestUtils.setField(existingReview, "id", reviewId);
+		// repository 에서 기존 리뷰가 있는지 확인
+		when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(existingReview));
+		ReviewUpdateRequestDto updateRequestDto = new ReviewUpdateRequestDto(5);
+
+		//when, then
+		ReviewExceptions exceptions = assertThrows(
+			ReviewExceptions.class,
+			() -> reviewService.updateReview(reviewId, updateRequestDto, requestMemberId)
+		);
+
+		//검증
+		assertEquals(HAS_NOT_PERMISSION, exceptions.getExceptionCode());
+	}
+}

--- a/src/test/java/com/sparta/outsourcing/domain/store/entity/StoreTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/store/entity/StoreTest.java
@@ -1,0 +1,50 @@
+package com.sparta.outsourcing.domain.store.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Time;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sparta.outsourcing.domain.member.entity.Member;
+
+class StoreTest {
+
+	private Store store;
+	private Member member;
+
+	@BeforeEach
+	void setUp() {
+		member = new Member();
+		store = Store.createOf("Test store", Time.valueOf("09:00:00"), Time.valueOf("21:00:00"), 10000, member);
+	}
+
+	@Test
+	void testCreateStore() {
+		assertEquals("Test store", store.getStoreName());
+		assertEquals(Time.valueOf("09:00:00"), store.getOpenTime());
+		assertEquals(Time.valueOf("21:00:00"), store.getCloseTime());
+		assertEquals(10000, store.getMinPrice());
+		assertTrue(store.isOpen());
+		assertFalse(store.isInactive());
+		assertEquals(member, store.getMember());
+	}
+
+	@Test
+	void testUpdateStore() {
+		store.update(Time.valueOf("10:00:00"), Time.valueOf("20:00:00"), 15000, false);
+
+		assertEquals(Time.valueOf("10:00:00"), store.getOpenTime());
+		assertEquals(Time.valueOf("20:00:00"), store.getCloseTime());
+		assertEquals(15000, store.getMinPrice());
+		assertFalse(store.isOpen());
+	}
+
+	@Test
+	void testDeleteStore() {
+		store.delete();
+
+		assertTrue(store.isInactive());
+	}
+}

--- a/src/test/java/com/sparta/outsourcing/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/store/service/StoreServiceTest.java
@@ -1,0 +1,75 @@
+package com.sparta.outsourcing.domain.store.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Time;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sparta.outsourcing.domain.member.entity.Member;
+import com.sparta.outsourcing.domain.member.entity.MemberRole;
+import com.sparta.outsourcing.domain.member.repository.MemberRepository;
+import com.sparta.outsourcing.domain.menu.repository.MenuRepository;
+import com.sparta.outsourcing.domain.review.repository.ReviewRepository;
+import com.sparta.outsourcing.domain.store.dto.StoreRequestDto;
+import com.sparta.outsourcing.domain.store.dto.StoreResponseDto;
+import com.sparta.outsourcing.domain.store.entity.Store;
+import com.sparta.outsourcing.domain.store.repository.StoreRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+	@InjectMocks
+	private StoreService storeService;
+
+	@Mock
+	private StoreRepository storeRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private MenuRepository menuRepository;
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Test
+	@DisplayName("정상적인 가게 생성이 이루어집니다.")
+	void 가게생성_성공() {
+		// given
+		Member owner = Member.createOf(null, null, null, null, MemberRole.OWNER);
+		StoreRequestDto requestDto = new StoreRequestDto("test store", Time.valueOf("09:00:00"), Time.valueOf("21:30:00"), 10000);
+		Store store = mock(Store.class);
+
+		doReturn(LocalDateTime.now()).when(store).getCreatedAt();
+		doReturn(LocalDateTime.now()).when(store).getModifiedAt();
+		doReturn("test store").when(store).getStoreName();
+		doReturn(Time.valueOf("09:00:00")).when(store).getOpenTime();
+		doReturn(Time.valueOf("21:30:00")).when(store).getCloseTime();
+		doReturn(10000).when(store).getMinPrice();
+
+		storeService = new StoreService(storeRepository, memberRepository, menuRepository, reviewRepository);
+
+		// stub
+		when(memberRepository.findById(1L)).thenReturn(Optional.of(owner));
+		when(storeRepository.save(any(Store.class))).thenReturn(store);
+
+		// when
+		StoreResponseDto responseDto = storeService.createStore(requestDto, 1L);
+
+		// then
+		assertEquals("test store", responseDto.getStoreName());
+		assertEquals(Time.valueOf("09:00:00"), responseDto.getOpenTime());
+		assertEquals(Time.valueOf("21:30:00"), responseDto.getCloseTime());
+		assertEquals(10000, responseDto.getMinPrice());
+	}
+}

--- a/src/test/java/com/sparta/outsourcing/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/store/service/StoreServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sparta.outsourcing.domain.like.repository.LikeRepository;
 import com.sparta.outsourcing.domain.member.entity.Member;
 import com.sparta.outsourcing.domain.member.entity.MemberRole;
 import com.sparta.outsourcing.domain.member.repository.MemberRepository;
@@ -42,6 +43,9 @@ class StoreServiceTest {
 	@Mock
 	private ReviewRepository reviewRepository;
 
+	@Mock
+	private LikeRepository likeRepository;
+
 	@Test
 	@DisplayName("정상적인 가게 생성이 이루어집니다.")
 	void 가게생성_성공() {
@@ -57,7 +61,7 @@ class StoreServiceTest {
 		doReturn(Time.valueOf("21:30:00")).when(store).getCloseTime();
 		doReturn(10000).when(store).getMinPrice();
 
-		storeService = new StoreService(storeRepository, memberRepository, menuRepository, reviewRepository);
+		storeService = new StoreService(storeRepository, memberRepository, menuRepository, reviewRepository, likeRepository);
 
 		// stub
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(owner));


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게 수정했나보다 무엇을 왜 수정했는지 설명해주세요. -->
Like Entity 추가
- 가지는 필드: id, Member, Store

서비스 로직
1. [POST}즐겨찾기 등록(/api/stores/like)
2. [DELETE]즐겨찾기 해제(/api/stores/unlike)

발생 가능한 예외상황
1. 등록
  > 내가 이미 좋아요를 누른 경우
  > 폐업한 가게에 좋아요를 누른 경우
2. 해제
  > 좋아요를 누른 적이 없는 경우

추가 수정 사항
가게 전체 조회 시, memberId를 같이 전달하도록 API Controller 로직 수정
getAllStoreByName, getAllStore 메서드로 전체 조회할 때 내가 즐겨찾기 한 가게가 모두 위에 수정일자를 기준으로 내림차순 정렬하고, 그 아래로 즐겨찾기 하지 않은 다른 가게들 최대 5개가 수정일자 기준 내림차순 정렬하도록 변경

<!---- Resolves: #72 -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).