### PR TITLE
feat: 가게 공지사항 수정 및 삭제 기능 도입[도전]

### DIFF
--- a/src/main/java/com/sparta/outsourcing/domain/store/controller/StoreAnnouncementController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/controller/StoreAnnouncementController.java
@@ -1,0 +1,44 @@
+package com.sparta.outsourcing.domain.store.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.outsourcing.domain.store.dto.AnnouncementRequestDto;
+import com.sparta.outsourcing.domain.store.service.StoreAnnouncementService;
+import com.sparta.outsourcing.domain.store.service.StoreService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores")
+public class StoreAnnouncementController {
+
+	private final StoreAnnouncementService storeAnnouncementService;
+
+	@PutMapping("/{storeId}/announcement")
+	public ResponseEntity<Void> updateAnnouncement(
+		@PathVariable Long storeId,
+		@RequestBody AnnouncementRequestDto requestDto,
+		@RequestAttribute("id") Long memberId
+	) {
+		storeAnnouncementService.updateAnnouncement(storeId, requestDto, memberId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/{storeId}/announcement")
+	public ResponseEntity<Void> deleteAnnouncement(
+		@PathVariable Long storeId,
+		@RequestAttribute("id") Long memberId
+	) {
+		storeAnnouncementService.deleteAnnouncement(storeId, memberId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/AnnouncementRequestDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/AnnouncementRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.outsourcing.domain.store.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AnnouncementRequestDto {
+	private String announcement;
+}

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/CategoryStoreResponseDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/CategoryStoreResponseDto.java
@@ -18,6 +18,8 @@ public class CategoryStoreResponseDto {
 	private String storeName;
 	private Time openTime;
 	private Time closeTime;
+	private int minPrice;
+	private String announcement;
 	private String createdAt;
 	private String modifiedAt;
 	private Page<MenuResponseFromStoreDto> menus;
@@ -28,6 +30,8 @@ public class CategoryStoreResponseDto {
 		this.storeName = store.getStoreName();
 		this.openTime = store.getOpenTime();
 		this.closeTime = store.getCloseTime();
+		this.minPrice = store.getMinPrice();
+		this.announcement = store.getAnnouncement();
 		this.createdAt = store.getCreatedAt().toString();
 		this.modifiedAt = store.getModifiedAt().toString();
 		this.menus = menus;

--- a/src/main/java/com/sparta/outsourcing/domain/store/dto/DetailedStoreResponseDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/dto/DetailedStoreResponseDto.java
@@ -18,6 +18,8 @@ public class DetailedStoreResponseDto {
 	private String storeName;
 	private Time openTime;
 	private Time closeTime;
+	private int minPrice;
+	private String announcement;
 	private String createdAt;
 	private String modifiedAt;
 	private Page<MenuResponseFromStoreDto> menus;
@@ -28,6 +30,8 @@ public class DetailedStoreResponseDto {
 		this.storeName = store.getStoreName();
 		this.openTime = store.getOpenTime();
 		this.closeTime = store.getCloseTime();
+		this.minPrice = store.getMinPrice();
+		this.announcement = store.getAnnouncement();
 		this.createdAt = store.getCreatedAt().toString();
 		this.modifiedAt = store.getModifiedAt().toString();
 		this.menus = menus;

--- a/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/entity/Store.java
@@ -39,6 +39,9 @@ public class Store extends TimeStamped {
 	private int minPrice;
 
 	@Column(nullable = false)
+	private String announcement;
+
+	@Column(nullable = false)
 	private boolean open;
 
 	@Column(nullable = false)
@@ -55,6 +58,7 @@ public class Store extends TimeStamped {
 		this.openTime = openTime;
 		this.closeTime = closeTime;
 		this.minPrice = minPrice;
+		this.announcement = "공지사항을 입력해 주세요.";
 		this.open = true;
 		this.inactive = false;
 		this.member = member;
@@ -73,5 +77,13 @@ public class Store extends TimeStamped {
 
 	public void delete() {
 		this.inactive = true;
+	}
+
+	public void updateAnnouncement(String announcement) {
+		this.announcement = announcement;
+	}
+
+	public void deleteAnnouncement() {
+		this.announcement = "공지사항을 입력해 주세요.";
 	}
 }

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreAnnouncementService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreAnnouncementService.java
@@ -1,0 +1,65 @@
+package com.sparta.outsourcing.domain.store.service;
+
+import static com.sparta.outsourcing.common.exception.enums.ExceptionCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.outsourcing.common.exception.customException.StoreExceptions;
+import com.sparta.outsourcing.domain.member.entity.Member;
+import com.sparta.outsourcing.domain.member.repository.MemberRepository;
+import com.sparta.outsourcing.domain.store.dto.AnnouncementRequestDto;
+import com.sparta.outsourcing.domain.store.entity.Store;
+import com.sparta.outsourcing.domain.store.repository.StoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StoreAnnouncementService {
+	
+	private final StoreRepository storeRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void updateAnnouncement(Long storeId, AnnouncementRequestDto requestDto, Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new StoreExceptions(NOT_FOUND_USER)
+		);
+
+		Store store = storeRepository.findById(storeId).orElseThrow(
+			() -> new StoreExceptions(NOT_FOUND_STORE)
+		);
+
+		if (store.getMember().getId() != member.getId()) {
+			throw new StoreExceptions(ONLY_OWNER_ALLOWED);
+		}
+
+		if (store.isInactive()) {
+			throw new StoreExceptions(STORE_OUT_OF_BUSINESS);
+		}
+
+		store.updateAnnouncement(requestDto.getAnnouncement());
+	}
+
+	@Transactional
+	public void deleteAnnouncement(Long storeId, Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+			() -> new StoreExceptions(NOT_FOUND_USER)
+		);
+
+		Store store = storeRepository.findById(storeId).orElseThrow(
+			() -> new StoreExceptions(NOT_FOUND_STORE)
+		);
+
+		if (store.getMember().getId() != member.getId()) {
+			throw new StoreExceptions(ONLY_OWNER_ALLOWED);
+		}
+
+		if (store.isInactive()) {
+			throw new StoreExceptions(STORE_OUT_OF_BUSINESS);
+		}
+
+		store.deleteAnnouncement();
+	}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/store/service/StoreService.java
@@ -116,6 +116,24 @@ public class StoreService {
 		);
 	}
 
+	public CategoryStoreResponseDto getOneStoreCategory(Long storeId, String category) {
+		Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreExceptions(NOT_FOUND_STORE));
+
+		Pageable menuPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
+		Page<Menu> menus = menuRepository.findAllByStoreAndCategoryAndInactiveFalse(store, category, menuPageable);
+		if(menus.isEmpty()) {
+			throw new StoreExceptions(NOT_FOUND_CATEGORY);
+		}
+
+		Pageable reviewPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
+		Page<Review> reviews = reviewRepository.findAllByStoreAndInactiveFalse(store, reviewPageable);
+
+		return new CategoryStoreResponseDto(
+			store,
+			menus.map(MenuResponseFromStoreDto::new)
+		);
+	}
+
 	@Transactional
 	public StoreResponseDto updateStore(Long storeId, @Valid StoreUpdateRequestDto requestDto, Long memberId) {
 		Store store = storeRepository.findById(storeId).orElseThrow(
@@ -161,23 +179,5 @@ public class StoreService {
 		List<Menu> menus = menuRepository.findAllByStoreAndInactiveFalse(store);
 		menus.forEach(Menu::delete);
 		menuRepository.saveAll(menus);
-	}
-
-	public CategoryStoreResponseDto getOneStoreCategory(Long storeId, String category) {
-		Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreExceptions(NOT_FOUND_STORE));
-
-		Pageable menuPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
-		Page<Menu> menus = menuRepository.findAllByStoreAndCategoryAndInactiveFalse(store, category, menuPageable);
-		if(menus.isEmpty()) {
-			throw new StoreExceptions(NOT_FOUND_CATEGORY);
-		}
-
-		Pageable reviewPageable = PageRequest.of(0, 5, Sort.by("modifiedAt").descending());
-		Page<Review> reviews = reviewRepository.findAllByStoreAndInactiveFalse(store, reviewPageable);
-
-		return new CategoryStoreResponseDto(
-			store,
-			menus.map(MenuResponseFromStoreDto::new)
-		);
 	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게 수정했나보다 무엇을 왜 수정했는지 설명해주세요. -->
가게 공지사항

Store Entity에 Column(새 필드) 추가
private String announcement;

공지사항을 관리하는 controller, service 추가

announcement는 수정, 삭제만 가능 (가게를 생성 시 기본값을 가지고 있음)
[PUT]수정(/api/stores/{storeId}/announcement)
[DELETE]삭제(/api/stores/{storeId}/announcement)

예외사항

1. 수정 시
> 가게 사장님이 아닌 사람이 수정 요청을 보낸 경우
> 폐업한 가게일 경우

2. 삭제 시
> 가게 사장님이 아닌 사람이 수정 요청을 보낸 경우
> 폐업한 가게일 경우


추가 사항

가게 단일 조회 시 공지사항이 같이 조회되도록 수정
가게 단일 조회 시 최소 주문 금액이 변경되지 않던 오류 수정
<!---- Resolves: #89 -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).